### PR TITLE
Patching the Momentum Budgets into LOFS IO

### DIFF
--- a/src/Makefile.kth.parallel
+++ b/src/Makefile.kth.parallel
@@ -1,0 +1,101 @@
+#ORF - MPI/OMP version
+
+ZFP=/home1/06818/khalbert/installs/zfp
+HDF5ZFP=/home1/06818/khalbert/installs/H5Z-ZFP/install
+NETCDF=$(TACC_NETCDF_DIR)
+FC=h5pfc
+OPTS =  -I$(HDF5ZFP)/include -I$(NETCDF)/include
+OPTS += -O3 -xHost -ip -assume byterecl -fp-model precise -ftz -no-fma -qopenmp
+CPP  = cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
+DM = -DMPI 
+OUTPUTOPT =  -DCOREX=2 -DCOREY=7
+#OUTPUTOPT =  -DCOREX=1 -DCOREY=1
+OUTPUTOPT += -DFFLUSH=flush -DMPIO=H5FD_MPIO_COLLECTIVE_F -DUSE_ZFP_COMPRESSION -DNFILES_PER_WRITE=5000 -DPARCELS
+
+LINKOPTS  = -L$(ZFP)/lib -L$(HDF5ZFP)/lib -L$(NETCDF)/lib  -lh5zzfp -lzfp -lnetcdf -lnetcdff
+
+SRC   = lofs-newcomm.F lofs-mod.F constants.F input.F adv.F adv_routines.F anelp.F azimavg.F base.F bc.F cm1.F cm1libs.F comm.F testcase_simple_phys.F \
+		diff2.F goddard.F hifrq.F init3d.F init_physics.F init_surface.F init_terrain.F interp_routines.F kessler.F lfoice.F maxmin.F \
+		misclibs.F morrison.F module_mp_nssl_2mom.F param.F parcel.F pdef.F pdcomp.F poiss.F sfcphys.F singleton.F radiation_driver.F \
+		solve.F sounde.F sound.F soundns.F soundcb.F statpack.F stopcm1.F thompson.F module_mp_radar.F turb.F turbdiag.F \
+		radlib3d.F irrad3d.F sorad3d.F radtrns3d.F getcape.F ysu.F sfclay.F sfclayrev.F slab.F oml.F \
+		module_ra_etc.F module_ra_rrtmg_lw.F module_ra_rrtmg_sw.F writeout_pcl_nc.F
+
+OBJS = $(addsuffix .o, $(basename $(SRC)))
+
+FFLAGS  =  $(OPTS)
+AR      = ar cru
+
+.SUFFIXES:
+.SUFFIXES:      .F .f90 .o
+
+all : newcomm lofs cm1
+
+cm1:			$(OBJS)
+			$(FC) $(OBJS) $(FFLAGS) $(OUTPUTINC) $(OUTPUTLIB) $(LINKOPTS) -o ../run/cm1.exe
+			$(AR) onefile.F $(SRC)
+			mv onefile.F ../run
+
+newcomm: lofs-newcomm.o
+lofs: lofs-mod.o
+
+.F.o:
+			$(CPP) $(DM) $(DP) $(ADV) $(OUTPUTOPT) $*.F > $*.f90
+			$(FC) $(FFLAGS) $(OUTPUTINC) -c $*.f90
+
+%.f90: %.F
+			$(CPP) $(DM) $(OUTPUTOPT) $< > $@
+code:
+			$(AR) onefile.F $(SRC)
+			mv onefile.F ../run
+
+clean:
+			rm -f *.f90 *.o *.a *.s *.mod
+
+lofs-mod.o: adv_routines.o misclibs.o constants.o input.o lofs-newcomm.o lofs-hdfio.f90 lofs-misc.f90 lofs-swaths.f90 lofs-hdfmisc.f90 lofs-hdfprelim.f90 lofs-writeout.f90 lofs-calc.f90 lofs-restart.f90
+adv.o: constants.o input.o pdef.o adv_routines.o
+adv_routines.o: input.o constants.o pdef.o comm.o
+anelp.o: constants.o input.o misclibs.o bc.o poiss.o
+azimavg.o: input.o constants.o cm1libs.o
+base.o: constants.o input.o bc.o comm.o goddard.o cm1libs.o getcape.o
+bc.o: constants.o input.o
+cm1.o: constants.o input.o param.o base.o init3d.o misclibs.o solve.o diff2.o turb.o statpack.o radiation_driver.o radtrns3d.o turbdiag.o azimavg.o hifrq.o parcel.o init_physics.o init_surface.o
+cm1libs.o: input.o constants.o
+comm.o: input.o bc.o
+diff2.o: constants.o input.o
+goddard.o: constants.o input.o cm1libs.o
+hifrq.o: input.o constants.o cm1libs.o
+init3d.o:  constants.o input.o misclibs.o cm1libs.o bc.o comm.o module_mp_nssl_2mom.o poiss.o parcel.o
+init_physics.o: constants.o input.o sfclay.o sfclayrev.o slab.o radtrns3d.o irrad3d.o goddard.o module_ra_rrtmg_lw.o module_ra_rrtmg_sw.o
+init_surface.o: constants.o input.o oml.o
+init_terrain.o: constants.o input.o bc.o comm.o adv_routines.o
+interp_routines.o: constants.o input.o
+irrad3d.o: radlib3d.o
+kessler.o: constants.o input.o
+lfoice.o: input.o
+maxmin.o: input.o
+misclibs.o: constants.o input.o goddard.o lfoice.o
+module_mp_radar.o: module_ra_etc.o
+module_ra_rrtmg_lw.o: module_ra_etc.o
+module_ra_rrtmg_sw.o: module_ra_etc.o module_ra_rrtmg_lw.o
+morrison.o: input.o constants.o
+param.o: constants.o input.o init_terrain.o bc.o comm.o thompson.o morrison.o module_mp_nssl_2mom.o goddard.o lfoice.o
+parcel.o: constants.o input.o cm1libs.o bc.o comm.o writeout_pcl_nc.o
+pdef.o: input.o bc.o comm.o
+pdcomp.o: constants.o input.o adv.o poiss.o
+poiss.o: input.o singleton.o
+radiation_driver.o: constants.o input.o bc.o radtrns3d.o module_ra_etc.o module_ra_rrtmg_lw.o module_ra_rrtmg_sw.o
+radtrns3d.o: irrad3d.o sorad3d.o radlib3d.o
+sfcphys.o: constants.o input.o cm1libs.o
+solve.o: constants.o input.o bc.o comm.o adv.o adv_routines.o diff2.o turb.o sound.o sounde.o soundns.o soundcb.o anelp.o misclibs.o kessler.o thompson.o morrison.o module_mp_nssl_2mom.o goddard.o lfoice.o testcase_simple_phys.o parcel.o pdcomp.o
+sorad3d.o: radlib3d.o
+sound.o: constants.o input.o misclibs.o bc.o comm.o
+sounde.o: constants.o input.o misclibs.o bc.o comm.o
+soundcb.o: constants.o input.o misclibs.o bc.o comm.o
+soundns.o: constants.o input.o misclibs.o bc.o
+statpack.o: constants.o input.o maxmin.o misclibs.o cm1libs.o
+testcase_simple_phys.o: constants.o input.o
+thompson.o: input.o module_mp_radar.o module_ra_etc.o
+turb.o: constants.o input.o bc.o comm.o sfcphys.o sfclay.o sfclayrev.o slab.o oml.o ysu.o cm1libs.o
+turbdiag.o: constants.o input.o interp_routines.o cm1libs.o getcape.o
+writeout_pcl_nc.o: constants.o input.o

--- a/src/lofs-writeout.F
+++ b/src/lofs-writeout.F
@@ -986,7 +986,7 @@ vbudget: if (output_vbudget.eq.1) then
           do k=1,maxk
           do j=1,nj
           do i=1,ni
-            var3d(i,j,k) = =vdiag(i,j,k,vd_vturb)
+            var3d(i,j,k) = vdiag(i,j,k,vd_vturb)
           enddo
           enddo
           enddo

--- a/src/lofs-writeout.F
+++ b/src/lofs-writeout.F
@@ -728,10 +728,7 @@
 ! stagger points are duplicated on adjacent ranks anyway
 
 ! But, we should have the option interpolating to the scalar mesh when we read these into hdf2nc or whatever
-
 wbudget: if (output_wbudget.eq.1) then
-
-!       elseif( trim(name_output(n)).eq.'wb_hadv' )then
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -752,8 +749,6 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_hadv_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_vadv' )then
-
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -773,8 +768,8 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_vadv_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_hturb' )then
 
+        if( cm1setup.ge.1 .or. ipbl.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -790,7 +785,6 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_hturb_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_vturb' )then
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -807,8 +801,9 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_vturb_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_hidiff' )then
+        endif
 
+        if( hadvordrv.eq.3 .or. hadvordrv.eq.5 .or. hadvordrv.eq.7 .or. hadvordrv.eq.9 .or. advwenov.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -824,8 +819,9 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_hidiff_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_vidiff' )then
+        endif
 
+        if( vadvordrv.eq.3 .or. vadvordrv.eq.5 .or. vadvordrv.eq.7 .or. vadvordrv.eq.9 .or. advwenov.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -841,8 +837,9 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_vidiff_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_hediff' )then
+        endif
 
+        if( idiff.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -858,8 +855,7 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_hediff_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_vediff' )then
-
+          if( difforder.eq.2 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -875,7 +871,8 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_vediff_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_pgrad' )then
+          endif
+        endif
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -892,8 +889,8 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_pgrad_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_rdamp' )then
 
+        if( irdamp.ge.1 .or. hrdamp.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -909,7 +906,7 @@ wbudget: if (output_wbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_rdamp_acc)
 
-!       elseif( trim(name_output(n)).eq.'wb_buoy' )then
+        endif
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -925,11 +922,10 @@ wbudget: if (output_wbudget.eq.1) then
           description="w budget: buoyancy"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,wb_buoy_acc)
+
 endif wbudget
 
 vbudget: if (output_vbudget.eq.1) then
-!       elseif( trim(name_output(n)).eq.'ub_hadv' )then
-
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -949,7 +945,6 @@ vbudget: if (output_vbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_hadv_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_vadv' )then
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -970,8 +965,7 @@ vbudget: if (output_vbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_vadv_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_hturb' )then
-
+        if( cm1setup.ge.1 .or. ipbl.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -987,14 +981,12 @@ vbudget: if (output_vbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_hturb_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_vturb' )then
-
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
           do j=1,nj
           do i=1,ni
-            var3d(i,j,k) = vdiag(i,j,k,vd_vturb)
+            var3d(i,j,k) = =vdiag(i,j,k,vd_vturb)
           enddo
           enddo
           enddo
@@ -1004,8 +996,8 @@ vbudget: if (output_vbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_vturb_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_hidiff' )then
-
+        endif
+        if( hadvordrv.eq.3 .or. hadvordrv.eq.5 .or. hadvordrv.eq.7 .or. hadvordrv.eq.9 .or. advwenov.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1020,9 +1012,9 @@ vbudget: if (output_vbudget.eq.1) then
           description="v budget: horiz implicit diffusion"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_hidiff_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_vidiff' )then
-
+        if( vadvordrv.eq.3 .or. vadvordrv.eq.5 .or. vadvordrv.eq.7 .or. vadvordrv.eq.9 .or. advwenov.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1037,9 +1029,8 @@ vbudget: if (output_vbudget.eq.1) then
           description="v budget: vert implicit diffusion"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_vidiff_acc)
-
-!       elseif( trim(name_output(n)).eq.'ub_hediff' )then
-
+        endif
+        if( idiff.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1055,42 +1046,42 @@ vbudget: if (output_vbudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_hediff_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_vediff' )then
+
+          if( difforder.eq.2 )then
+!$omp parallel do default(shared)  &
+!$omp private(i,j,k)
+            do k=1,maxk
+            do j=1,nj
+            do i=1,ni
+              var3d(i,j,k) = vdiag(i,j,k,vd_vediff)
+            enddo
+            enddo
+            enddo
+
+            varname="vb_vediff"
+            description="v budget: vert explicit diffusion"
+            units="m/s/s"
+            call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_vediff_acc)
+          endif
+        endif
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
-          do k=1,maxk
-          do j=1,nj
-          do i=1,ni
-            var3d(i,j,k) = vdiag(i,j,k,vd_vediff)
-          enddo
-          enddo
-          enddo
+        do k=1,maxk
+        do j=1,nj
+        do i=1,ni
+          var3d(i,j,k) = vdiag(i,j,k,vd_pgrad)
+        enddo
+        enddo
+        enddo
 
-          varname="vb_vediff"
-          description="v budget: vert explicit diffusion"
-          units="m/s/s"
-          call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_vediff_acc)
+        varname="vb_pgrad"
+        description="v budget: pressure gradient"
+        units="m/s/s"
+        call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_pgrad_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_pgrad' )then
 
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k)
-          do k=1,maxk
-          do j=1,nj
-          do i=1,ni
-            var3d(i,j,k) = vdiag(i,j,k,vd_pgrad)
-          enddo
-          enddo
-          enddo
-
-          varname="vb_pgrad"
-          description="v budget: pressure gradient"
-          units="m/s/s"
-          call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_pgrad_acc)
-
-!       elseif( trim(name_output(n)).eq.'ub_rdamp' )then
-
+        if( irdamp.ge.1 .or. hrdamp.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1105,9 +1096,9 @@ vbudget: if (output_vbudget.eq.1) then
           description="v budget: Rayleigh damper"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_rdamp_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_cor' )then
-
+        if( icor.eq.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1122,9 +1113,9 @@ vbudget: if (output_vbudget.eq.1) then
           description="v budget: Coriolis acceleration"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_cor_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_pbl' )then
-
+        if( ipbl.eq.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1139,12 +1130,9 @@ vbudget: if (output_vbudget.eq.1) then
           description="v budget: PBL scheme"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_pbl_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_subs' )then
-
-! ORF: Check for dosub, if it's false (which it hsould be) skip all _subs budgets, they are for test cases.
-! Create a boolean 'odd_order_advection' or similar to determine whether to do _ediff (and check what_idiff is)
-
+        if( dosub )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1159,11 +1147,10 @@ vbudget: if (output_vbudget.eq.1) then
           description="v budget: large-scale subsidence "
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,vb_subs_acc)
-
+        endif
 endif vbudget
 
 ubudget: if (output_ubudget.eq.1) then
-!       elseif( trim(name_output(n)).eq.'ub_hadv' )then
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -1184,7 +1171,6 @@ ubudget: if (output_ubudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_hadv_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_vadv' )then
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -1205,8 +1191,8 @@ ubudget: if (output_ubudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_vadv_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_hturb' )then
 
+        if( cm1setup.ge.1 .or. ipbl.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1221,8 +1207,6 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: horizontal parameterized turbulence"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_hturb_acc)
-
-!       elseif( trim(name_output(n)).eq.'ub_vturb' )then
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -1239,8 +1223,9 @@ ubudget: if (output_ubudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_vturb_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_hidiff' )then
+        endif
 
+        if( hadvordrv.eq.3 .or. hadvordrv.eq.5 .or. hadvordrv.eq.7 .or. hadvordrv.eq.9 .or. advwenov.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1255,9 +1240,9 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: horiz implicit diffusion"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_hidiff_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_vidiff' )then
-
+        if( vadvordrv.eq.3 .or. vadvordrv.eq.5 .or. vadvordrv.eq.7 .or. vadvordrv.eq.9 .or. advwenov.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1272,9 +1257,9 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: vert implicit diffusion"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_vidiff_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_hediff' )then
-
+        if( idiff.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1290,42 +1275,42 @@ ubudget: if (output_ubudget.eq.1) then
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_hediff_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_vediff' )then
+
+          if( difforder.eq.2 )then
+!$omp parallel do default(shared)  &
+!$omp private(i,j,k)
+            do k=1,maxk
+            do j=1,nj
+            do i=1,ni
+              var3d(i,j,k) = udiag(i,j,k,ud_vediff)
+            enddo
+            enddo
+            enddo
+
+            varname="ub_vediff"
+            description="u budget: vert explicit diffusion"
+            units="m/s/s"
+            call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_vediff_acc)
+          endif
+        endif
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
-          do k=1,maxk
-          do j=1,nj
-          do i=1,ni
-            var3d(i,j,k) = udiag(i,j,k,ud_vediff)
-          enddo
-          enddo
-          enddo
+        do k=1,maxk
+        do j=1,nj
+        do i=1,ni
+          var3d(i,j,k) = udiag(i,j,k,ud_pgrad)
+        enddo
+        enddo
+        enddo
 
-          varname="ub_vediff"
-          description="u budget: vert explicit diffusion"
-          units="m/s/s"
-          call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_vediff_acc)
+        varname="ub_pgrad"
+        description="u budget: pressure gradient"
+        units="m/s/s"
+        call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_pgrad_acc)
 
-!       elseif( trim(name_output(n)).eq.'ub_pgrad' )then
 
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k)
-          do k=1,maxk
-          do j=1,nj
-          do i=1,ni
-            var3d(i,j,k) = udiag(i,j,k,ud_pgrad)
-          enddo
-          enddo
-          enddo
-
-          varname="ub_pgrad"
-          description="u budget: pressure gradient"
-          units="m/s/s"
-          call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_pgrad_acc)
-
-!       elseif( trim(name_output(n)).eq.'ub_rdamp' )then
-
+        if( irdamp.ge.1 .or. hrdamp.ge.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1340,9 +1325,9 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: Rayleigh damper"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_rdamp_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_cor' )then
-
+        if( icor.eq.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1357,9 +1342,9 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: Coriolis acceleration"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_cor_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_pbl' )then
-
+        if( ipbl.eq.1 )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1374,9 +1359,9 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: PBL scheme"
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_pbl_acc)
+        endif
 
-!       elseif( trim(name_output(n)).eq.'ub_subs' )then
-
+        if( dosub )then
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
           do k=1,maxk
@@ -1391,6 +1376,7 @@ ubudget: if (output_ubudget.eq.1) then
           description="u budget: large-scale subsidence "
           units="m/s/s"
           call h5_write_3d_float_scalar(threed_group_id,var3d,ninjnktype,ub_subs_acc)
+        endif
 
 endif ubudget
 


### PR DESCRIPTION
This patch addresses an issue where writeout-lofs.F, when configured to write out momentum budgets, would access arrays that did not exist. Turns out, certain budget arrays are only used/allocated in certain configurations. This adds the logic found in param.F regarding nudiag, nvdiag, and nwdiag to ensure that only the budgets being computed are saved to disk. 

This was tested with a 100 meter run from restart and tested with hdf2nc + ncview. The results look like they're working appropriately. 

![image](https://user-images.githubusercontent.com/1411265/93689640-17d38d00-fa96-11ea-8f09-c31cf2ca3e28.png)
